### PR TITLE
Respect devicePixelRatio

### DIFF
--- a/examples/src/demos/Bubbles/index.tsx
+++ b/examples/src/demos/Bubbles/index.tsx
@@ -97,6 +97,7 @@ export default function Bubbles() {
     <Canvas
       colorManagement
       camera={{ position: [0, 0, 3] }}
+      pixelRatio={window.devicePixelRatio}
       gl={{ powerPreference: 'high-performance', alpha: false, antialias: false, stencil: false, depth: false }}
     >
       <color attach="background" args={['#050505']} />

--- a/examples/src/demos/TakeControl/index.tsx
+++ b/examples/src/demos/TakeControl/index.tsx
@@ -16,6 +16,7 @@ function TakeControl() {
         shadowMap
         colorManagement
         camera={{ position: [0, 0, 3], far: 1000, fov: 70 }}
+        pixelRatio={window.devicePixelRatio}
         gl={{
           powerPreference: 'high-performance',
           alpha: false,

--- a/src/EffectComposer.tsx
+++ b/src/EffectComposer.tsx
@@ -36,7 +36,10 @@ const EffectComposer = forwardRef(
       return [effectComposer, pass]
     }, [camera, gl, multisampling, props, scene])
 
-    useEffect(() => void composer.setSize(size.width * devicePixelRatio, size.height * devicePixelRatio), [composer, size, devicePixelRatio])
+    useEffect(() => void composer.setSize(
+      size.width * window.devicePixelRatio,
+      size.height * window.devicePixelRatio
+    ), [composer, size, window.devicePixelRatio])
     useFrame((_, delta) => composer.render(delta), renderPriority)
 
     const group = useRef()

--- a/src/EffectComposer.tsx
+++ b/src/EffectComposer.tsx
@@ -36,7 +36,10 @@ const EffectComposer = forwardRef(
       return [effectComposer, pass]
     }, [camera, gl, multisampling, props, scene])
 
-    useEffect(() => void composer.setSize(size.width, size.height), [composer, size])
+    useEffect(() => {
+      composer.setSize(size.width, size.height)
+      composer.setPixelRatio(devicePixelRatio)
+    }, [composer, size])
     useFrame((_, delta) => composer.render(delta), renderPriority)
 
     const group = useRef()

--- a/src/EffectComposer.tsx
+++ b/src/EffectComposer.tsx
@@ -36,7 +36,7 @@ const EffectComposer = forwardRef(
       return [effectComposer, pass]
     }, [camera, gl, multisampling, props, scene])
 
-    useEffect(() => void composer.setSize(size.width * devicePixelRatio, size.height * devicePixelRatio), [composer, size])
+    useEffect(() => void composer.setSize(size.width * devicePixelRatio, size.height * devicePixelRatio), [composer, size, devicePixelRatio])
     useFrame((_, delta) => composer.render(delta), renderPriority)
 
     const group = useRef()

--- a/src/EffectComposer.tsx
+++ b/src/EffectComposer.tsx
@@ -36,10 +36,7 @@ const EffectComposer = forwardRef(
       return [effectComposer, pass]
     }, [camera, gl, multisampling, props, scene])
 
-    useEffect(() => {
-      composer.setSize(size.width, size.height)
-      composer.setPixelRatio(devicePixelRatio)
-    }, [composer, size])
+    useEffect(() => void composer.setSize(size.width * devicePixelRatio, size.height * devicePixelRatio), [composer, size])
     useFrame((_, delta) => composer.render(delta), renderPriority)
 
     const group = useRef()


### PR DESCRIPTION
In working on my own effects chain, I found some blurriness in textures that I eventually isolated to the `devicePixelRatio` not being set on the composer.

Switching over to `react-postprocessing`, it looks like it exhibits the same problem.

## Without `devicePixelRatio`
![image](https://user-images.githubusercontent.com/1865957/90315906-13431400-deed-11ea-9c52-46dd7b7bd146.png)

## With `devicePixelRatio`
![image](https://user-images.githubusercontent.com/1865957/90315899-032b3480-deed-11ea-9aa4-bca7329d2e6e.png)
