### PR TITLE
Fix opacity and blendFunction types in wrapEffect

### DIFF
--- a/src/util.tsx
+++ b/src/util.tsx
@@ -3,18 +3,14 @@ import { Vector2 } from 'three'
 import { ReactThreeFiber } from 'react-three-fiber'
 import { Effect, BlendFunction } from 'postprocessing'
 
+type DefaultProps = Partial<{ blendFunction: BlendFunction; opacity: number }>
+
 export const wrapEffect = <T extends new (...args: any[]) => Effect>(
   effectImpl: T,
   defaultBlendMode: BlendFunction = BlendFunction.NORMAL
-): ForwardRefExoticComponent<ConstructorParameters<typeof effectImpl>[0]> =>
+): ForwardRefExoticComponent<ConstructorParameters<typeof effectImpl>[0] & DefaultProps> =>
   forwardRef(function Wrap(
-    {
-      blendFunction,
-      opacity,
-      ...props
-    }: React.PropsWithChildren<
-      Partial<{ blendFunction: BlendFunction; opacity: number }> & ConstructorParameters<T>[0]
-    >,
+    { blendFunction, opacity, ...props }: React.PropsWithChildren<DefaultProps & ConstructorParameters<T>[0]>,
     ref
   ) {
     const effect: Effect = useMemo(() => new effectImpl(props), [props])


### PR DESCRIPTION
## Problem

Before, in `wrapEffect` the `opacity` and `blendFunction` props that are present in all effects, were inacessible, even though they were set in inside `wrapEffect`

![image](https://user-images.githubusercontent.com/35937217/93017269-012dc180-f5d0-11ea-82be-c0ab4d0c138d.png)

## Solution

this PR fixes it, so u can use `opacity` prop without errors



